### PR TITLE
Add designer command and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,27 @@ Available commands:
 - `startproject NAME` – generate a new project skeleton.
 - `startapp NAME` – create a new application skeleton.
 - `createsvgcolors` – build colored SVG resources.
+- `designer [UI_FILE]` – open Qt Designer for rapid UI creation.
 
 Configuration is handled via the `poutay_setting` environment variable which
 should contain the import path to a settings module. When not set, defaults from
 `conf.global_settings` are used.
+
+## نمونه کد ساده
+
+```python
+from views.ui_class import UIMain
+
+class MainWindow(UIMain):
+    widget_file = "ui/main.ui"
+
+if __name__ == "__main__":
+    MainWindow.show()
+    MainWindow().run()
+```
+
+برای طراحی رابط گرافیکی می‌توانید از دستور زیر برای اجرای خودکار Qt Designer استفاده کنید:
+
+```bash
+python poutay.py designer ui/main.ui
+```

--- a/bootstrap/multi_color_svg.py
+++ b/bootstrap/multi_color_svg.py
@@ -1,9 +1,10 @@
-from conf.settings import (
-    QRC_FILE,          # مسیر فایل qrc اصلی
-    QRC_FILE_FULL,     # مسیر فایل qrc کامل و ساخته شده (خروجی)
-    COMPILED_QRC_PY,   # مسیر فایل پایتون ساخته شده از qrc
-    PYSIDE6_RCC_PATH,  # مسیر ابزار pyside6-rcc برای کامپایل qrc
-)
+from pathlib import Path
+import subprocess
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+from bs4 import BeautifulSoup
+
+from conf import settings
 
 
 class SvgColorBuilder:
@@ -11,7 +12,7 @@ class SvgColorBuilder:
         self.colors = colors
         self.output_svg_dirs = output_svg_dirs
         # مسیر فایل اصلی qrc
-        self.qrc_path = Path(QRC_FILE)
+        self.qrc_path = Path(settings.QRC_FILE)
         # دایرکتوری فایل qrc (برای محاسبه مسیرهای نسبی)
         self.qrc_dir = self.qrc_path.parent
         # دایرکتوری برای ذخیره svg های رنگی (اگر وجود نداشت ایجاد می‌شود)
@@ -19,9 +20,9 @@ class SvgColorBuilder:
         self.svg_colors_dir.mkdir(parents=True, exist_ok=True)
 
         # مسیر فایل qrc کامل که ساخته می‌شود
-        self.qrc_full_path = Path(QRC_FILE_FULL)
+        self.qrc_full_path = Path(settings.QRC_FILE_FULL)
         # مسیر فایل پایتون خروجی qrc
-        self.compiled_qrc_py = Path(COMPILED_QRC_PY)
+        self.compiled_qrc_py = Path(settings.COMPILED_QRC_PY)
 
     def build(self):
         # خواندن محتوای فایل qrc اصلی به صورت متن
@@ -99,7 +100,7 @@ class SvgColorBuilder:
         print("[+] Compiling QRC → Python ...")
         # اجرای دستور کامپایل qrc به فایل پایتون
         subprocess.run(
-            [PYSIDE6_RCC_PATH, str(self.qrc_full_path), "-o", str(self.compiled_qrc_py)],
+            [settings.PYSIDE6_RCC_PATH, str(self.qrc_full_path), "-o", str(self.compiled_qrc_py)],
             check=True,
         )
         print(f"✅ Compiled: {self.compiled_qrc_py}")

--- a/poutay.py
+++ b/poutay.py
@@ -8,33 +8,133 @@ from pathlib import Path
 
 from conf import settings
 import runner
-from bootstrap.multi_color_svg import SvgColorBuilder
-
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 
 
-def cmd_run(args):
-    """Run application using runner module."""
-    runner.run()
+class CommandBase:
+    """Base class for CLI commands."""
+
+    name: str = ""
+    help: str = ""
+
+    @classmethod
+    def handler(cls, subparsers: argparse._SubParsersAction) -> None:
+        parser = subparsers.add_parser(cls.name, help=cls.help)
+        cls.add_arguments(parser)
+        parser.set_defaults(command=cls())
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        """Register command specific arguments."""
+        pass
+
+    def run(self, args: argparse.Namespace) -> None:  # pragma: no cover - base class
+        raise NotImplementedError
 
 
-def cmd_build(args):
-    """Build standalone executable using PyInstaller."""
-    target = Path(args.script)
-    build_dir = Path("build")
-    build_dir.mkdir(exist_ok=True)
-    subprocess.run([
-        "pyinstaller",
-        "--onefile",
-        str(target),
-        "--distpath",
-        str(build_dir),
-        "-y",
-    ], check=True)
+class RunCommand(CommandBase):
+    name = "run"
+    help = "Start the application defined in your settings."
+
+    def run(self, args: argparse.Namespace) -> None:
+        runner.run()
 
 
-def copytree(src: Path, dst: Path, name_map=None):
+class BuildCommand(CommandBase):
+    name = "build"
+    help = "Create a standalone executable using PyInstaller."
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("script", default="manage.py", nargs="?")
+
+    def run(self, args: argparse.Namespace) -> None:
+        target = Path(args.script)
+        build_dir = Path("build")
+        build_dir.mkdir(exist_ok=True)
+        subprocess.run([
+            "pyinstaller",
+            "--onefile",
+            str(target),
+            "--distpath",
+            str(build_dir),
+            "-y",
+        ], check=True)
+
+
+class StartProjectCommand(CommandBase):
+    name = "startproject"
+    help = "Generate a new project skeleton."
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("name")
+
+    def run(self, args: argparse.Namespace) -> None:
+        project_dir = Path(args.name)
+        template = TEMPLATES_DIR / "project"
+        copytree(template, project_dir)
+        print(f"Project created at {project_dir}")
+
+
+class StartAppCommand(CommandBase):
+    name = "startapp"
+    help = "Create a new application skeleton."
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("name")
+
+    def run(self, args: argparse.Namespace) -> None:
+        app_dir = Path(args.name)
+        template = TEMPLATES_DIR / "app"
+        copytree(template, app_dir)
+        print(f"App created at {app_dir}")
+
+
+class CreateSvgColorsCommand(CommandBase):
+    name = "createsvgcolors"
+    help = "Build colored SVG resources."
+
+    def run(self, args: argparse.Namespace) -> None:
+        from bootstrap.multi_color_svg import SvgColorBuilder
+
+        colors = getattr(settings, "SVG_COLORS", {})
+        out_dir = getattr(settings, "SVG_COLORS_DIR", "build/svg_colors")
+        builder = SvgColorBuilder(colors, out_dir)
+        builder.build()
+
+
+class DesignerCommand(CommandBase):
+    name = "designer"
+    help = "Launch Qt Designer (pyside6-designer)."
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("ui_file", nargs="?", help="Optional .ui file to open")
+
+    def run(self, args: argparse.Namespace) -> None:
+        cmd = ["pyside6-designer"]
+        if args.ui_file:
+            cmd.append(args.ui_file)
+        try:
+            subprocess.run(cmd, check=True)
+        except FileNotFoundError:
+            print("pyside6-designer not found. Please install PySide6.")
+
+
+COMMANDS = [
+    RunCommand,
+    BuildCommand,
+    StartProjectCommand,
+    StartAppCommand,
+    CreateSvgColorsCommand,
+    DesignerCommand,
+]
+
+
+def copytree(src: Path, dst: Path, name_map=None) -> None:
     for root, dirs, files in os.walk(src):
         rel = Path(root).relative_to(src)
         target_root = dst / rel
@@ -47,57 +147,19 @@ def copytree(src: Path, dst: Path, name_map=None):
             shutil.copy2(src_file, dst_file)
 
 
-def cmd_startproject(args):
-    project_dir = Path(args.name)
-    template = TEMPLATES_DIR / "project"
-    copytree(template, project_dir)
-    print(f"Project created at {project_dir}")
-
-
-def cmd_startapp(args):
-    app_dir = Path(args.name)
-    template = TEMPLATES_DIR / "app"
-    copytree(template, app_dir)
-    print(f"App created at {app_dir}")
-
-
-def cmd_createsvgcolors(args):
-    colors = getattr(settings, "SVG_COLORS", {})
-    out_dir = getattr(settings, "SVG_COLORS_DIR", "build/svg_colors")
-    builder = SvgColorBuilder(colors, out_dir)
-    builder.build()
-
-
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="poutay")
     sub = parser.add_subparsers(dest="command")
-
-    p_run = sub.add_parser("run")
-    p_run.set_defaults(func=cmd_run)
-
-    p_build = sub.add_parser("build")
-    p_build.add_argument("script", default="manage.py", nargs="?")
-    p_build.set_defaults(func=cmd_build)
-
-    p_sp = sub.add_parser("startproject")
-    p_sp.add_argument("name")
-    p_sp.set_defaults(func=cmd_startproject)
-
-    p_sa = sub.add_parser("startapp")
-    p_sa.add_argument("name")
-    p_sa.set_defaults(func=cmd_startapp)
-
-    p_svg = sub.add_parser("createsvgcolors")
-    p_svg.set_defaults(func=cmd_createsvgcolors)
-
+    for cmd in COMMANDS:
+        cmd.handler(sub)
     return parser
 
 
-def main(argv=None):
+def main(argv=None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
-    if hasattr(args, "func"):
-        args.func(args)
+    if hasattr(args, "command"):
+        args.command.run(args)
     else:
         parser.print_help()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import poutay
+from poutay import (
+    RunCommand,
+    BuildCommand,
+    StartProjectCommand,
+    StartAppCommand,
+    CreateSvgColorsCommand,
+    DesignerCommand,
+)
+
+
+def test_build_parser_returns_command_instances():
+    parser = poutay.build_parser()
+    args = parser.parse_args(["run"])
+    assert isinstance(args.command, RunCommand)
+    args = parser.parse_args(["designer"])
+    assert isinstance(args.command, DesignerCommand)
+
+
+def test_designer_run_handles_missing_executable():
+    parser = poutay.build_parser()
+    args = parser.parse_args(["designer"])
+    with mock.patch("subprocess.run", side_effect=FileNotFoundError) as mock_run:
+        args.command.run(args)
+        mock_run.assert_called_once()
+
+

--- a/views/ui_class.py
+++ b/views/ui_class.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import QApplication, QWidget
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtCore import QFile
 from core.signals import MetaSignals
-from conf.settings import FONT_PATH, QSS_PATH
+from conf import settings
 from action.base import ActionBase
 import assets_rc
 
@@ -132,7 +132,7 @@ class UIMain(metaclass=UIMainMeta):
 
         from PySide6.QtCore import QTextStream
 
-        file = QFile(QSS_PATH)
+        file = QFile(settings.QSS_PATH)
         if file.open(QFile.ReadOnly | QFile.Text):
             stream = QTextStream(file)
             qss = stream.readAll()
@@ -148,7 +148,7 @@ class UIMain(metaclass=UIMainMeta):
         self.setup()
 
     def setup(self):
-        self.set_font(FONT_PATH, size=12)
+        self.set_font(settings.FONT_PATH, size=12)
 
     def run(self):
         sys.exit(self.app.exec())


### PR DESCRIPTION
## Summary
- convert CLI commands to class-based structure
- add new `designer` command that launches Qt Designer
- fix settings imports in UI builder and SVG builder
- update README with usage instructions and sample code
- add unit tests for CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d18867bf08321be67e343b4342067