### PR TITLE
Add CLI modules to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name="poutay",
     version="0.1.0",
     packages=find_packages(),
+    py_modules=["poutay", "runner"],
     include_package_data=True,
     install_requires=[
         "PySide6",


### PR DESCRIPTION
## Summary
- include `poutay.py` and `runner.py` in the package to expose CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e079fa650832182fb83917f2592b0