### PR TITLE
Fix startproject templates packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include templates *

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     packages=find_packages(),
     py_modules=["poutay", "runner"],
     include_package_data=True,
+    package_data={"": ["templates/*", "templates/*/*", "templates/*/*/*"]},
     install_requires=[
         "PySide6",
         "cryptography",


### PR DESCRIPTION
## Summary
- include the templates directory in the source distribution
- package template files so `startproject` can create new projects everywhere

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e0d45c738832196c9d294269f0f31