### PR TITLE
Enable python -m poutay CLI invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ pip install -r requirements.txt
 
 ## Usage
 
-Run the CLI directly:
+Run the CLI directly using the module or script:
 
 ```bash
+# Via module execution
+python -m poutay --help
+
+# Or via the script
 python poutay.py run
 ```
 

--- a/poutay/__init__.py
+++ b/poutay/__init__.py
@@ -1,0 +1,35 @@
+"""Poutay package initializer.
+
+This package primarily exposes the command line interface implemented in the
+``poutay.py`` module that lives alongside this package in the distribution. The
+objects are imported dynamically so that ``import poutay`` provides access to
+the same API regardless of whether the module or package is imported first.
+"""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+_cli_path = Path(__file__).resolve().parent.parent / "poutay.py"
+_spec = spec_from_file_location("poutay_cli", _cli_path)
+_cli = module_from_spec(_spec)
+_spec.loader.exec_module(_cli)
+
+RunCommand = _cli.RunCommand
+BuildCommand = _cli.BuildCommand
+StartProjectCommand = _cli.StartProjectCommand
+StartAppCommand = _cli.StartAppCommand
+CreateSvgColorsCommand = _cli.CreateSvgColorsCommand
+DesignerCommand = _cli.DesignerCommand
+build_parser = _cli.build_parser
+main = _cli.main
+
+__all__ = [
+    "RunCommand",
+    "BuildCommand",
+    "StartProjectCommand",
+    "StartAppCommand",
+    "CreateSvgColorsCommand",
+    "DesignerCommand",
+    "build_parser",
+    "main",
+]

--- a/poutay/__main__.py
+++ b/poutay/__main__.py
@@ -1,0 +1,20 @@
+"""Entry point for ``python -m poutay``.
+
+This module proxies execution to the CLI implementation defined in the
+``poutay.py`` module located alongside this package.
+"""
+from importlib import import_module
+from pathlib import Path
+import runpy
+
+
+def main() -> None:
+    # Resolve path to the CLI module installed as ``poutay.py`` next to this
+    # package and execute it as a script. This mirrors the behaviour of the
+    # ``poutay`` console script defined in ``setup.py``.
+    module_path = Path(__file__).resolve().parent.parent / "poutay.py"
+    runpy.run_path(str(module_path), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/poutay/tests/test_cli.py
+++ b/poutay/tests/test_cli.py
@@ -1,8 +1,12 @@
 import sys
 from pathlib import Path
 from unittest import mock
+import subprocess
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# Ensure the project root is on the path so that ``import poutay`` resolves to
+# the CLI module defined at the repository root rather than the ``poutay``
+# package directory. ``parents[2]`` points to the repository root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import poutay
 from poutay import (
@@ -29,5 +33,18 @@ def test_designer_run_handles_missing_executable():
     with mock.patch("subprocess.run", side_effect=FileNotFoundError) as mock_run:
         args.command.run(args)
         mock_run.assert_called_once()
+
+
+def test_module_execution_via_dash_m(tmp_path):
+    """Ensure ``python -m poutay`` executes without error."""
+    result = subprocess.run(
+        [sys.executable, "-m", "poutay", "--help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        check=True,
+    )
+    assert "usage:" in result.stdout.lower()
 
 


### PR DESCRIPTION
## Summary
- add a `poutay.__main__` entry so `python -m poutay` works
- export CLI API from the package
- update tests and add coverage for module execution
- document the new invocation method in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e25da36208321bafbea6eb43711be